### PR TITLE
Bump rack from 2.2.6.2 to 2.2.6.3 (#23997)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,7 +503,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.6.2)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-cors (1.1.1)


### PR DESCRIPTION
Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>